### PR TITLE
V2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
 # Specify the project, its version and the used language
 project(libwrp
-        VERSION 1.0.1
+        VERSION 2.0.0
         LANGUAGES CXX)
 
 # To enable the C++11 standard, we have to add flags like -std=gnu+11 or so. CMake can take care of this:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A C++ library that stores libint2 calculated overlap, kinetic, nuclear and Coulo
 To install this library:
 1. download and untar the latest release
 
-        curl -OL "https://github.com/lelemmen/libwrp/archive/v1.0.1.tar.gz"
-        tar -xvzf v1.0.1.tar.gz
-        cd libwrp-1.0.1
+        curl -OL "https://github.com/lelemmen/libwrp/archive/v2.0.0.tar.gz"
+        tar -xvzf v2.0.0.tar.gz
+        cd libwrp-2.0.0
 
 2. perform an out-of-source cmake build:
 

--- a/include/Basis.hpp
+++ b/include/Basis.hpp
@@ -7,7 +7,7 @@
 #include <unsupported/Eigen/CXX11/Tensor>
 
 
-namespace Wrapper {
+namespace libwrp {
 
 class Basis {
 private:
@@ -53,6 +53,6 @@ public:
     void compute_two_electron_integrals();
 };
 
-} // namespace Wrapper
+} // namespace libwrp
 
 #endif // LIBWRP_BASIS_HPP

--- a/include/Basis.hpp
+++ b/include/Basis.hpp
@@ -17,6 +17,11 @@ public:
     Molecule molecule;
     const std::string name;
 
+    Eigen::MatrixXd S;  // The overlap integrals matrix for the given basis and molecule
+    Eigen::MatrixXd V;  // The nuclear integrals matrix for the given basis and molecule
+    Eigen::MatrixXd T;  // The kinetic integrals matrix for the given basis and molecule
+    Eigen::Tensor<double, 4> tei;  // The two-electron repulsion integrals tensor for the given basis and molecule
+
 
     // Constructors
     /** Constructor from a molecule and a basis name.
@@ -27,13 +32,25 @@ public:
     Basis(Molecule& molecule, const std::string& basis_name);
 
 
-    // Methods
+    /** Calculate and return the number of basis functions in the basis
+     */
     size_t nbf();
 
-    Eigen::MatrixXd compute_overlap_integrals();
-    Eigen::MatrixXd compute_nuclear_integrals();
-    Eigen::MatrixXd compute_kinetic_integrals();
-    Eigen::Tensor<double, 4> compute_two_electron_integrals();
+    /** Calculate and set the overlap integrals
+     */
+    void compute_overlap_integrals();
+
+    /** Calculate and set the kinetic integrals
+    */
+    void compute_kinetic_integrals();
+
+    /** Calculate and set the nuclear integrals
+    */
+    void compute_nuclear_integrals();
+
+    /** Calculate and set the kinetic integrals
+    */
+    void compute_two_electron_integrals();
 };
 
 } // namespace Wrapper

--- a/include/Molecule.hpp
+++ b/include/Molecule.hpp
@@ -5,7 +5,7 @@
 #include <string>
 
 
-namespace Wrapper {
+namespace libwrp {
 /** Parses a file name to obtain atoms
  *
  * @param filename
@@ -60,6 +60,6 @@ public:
     double internuclear_repulsion();
 };
 
-} // namespace Wrapper
+} // namespace libwrp
 
 #endif // LIBWRP_MOLECULE_HPP

--- a/include/geometry.hpp
+++ b/include/geometry.hpp
@@ -4,14 +4,14 @@
 #include <libint2.hpp>
 
 
-namespace Wrapper{
+namespace libwrp {
 
 /** @return the distance between two libint2::Atoms, in Bohr
  */
 double distance(const libint2::Atom& atom1, const libint2::Atom& atom2);
 
 
-} // namespace Wrapper
+} // namespace libwrp
 
 
 #endif // LIBWRP_GEOMETRY_HPP

--- a/include/integrals.hpp
+++ b/include/integrals.hpp
@@ -7,7 +7,7 @@
 #include <libint2.hpp>
 
 
-namespace Wrapper {
+namespace libwrp {
 
 /**
  * Given an operator type, an orbital basis and atoms, calculates the one-body integrals (associated to that operator type)
@@ -36,6 +36,6 @@ Eigen::Tensor<double, 4> compute_2body_integrals(const libint2::BasisSet& obs, c
  */
 void print_shell_sizes(const libint2::BasisSet& obs);
 
-} // namespace Wrapper
+} // namespace libwrp
 
 #endif // LIBWRP_INTEGRALS_HPP

--- a/include/libwrp.hpp
+++ b/include/libwrp.hpp
@@ -1,5 +1,5 @@
-#ifndef LIBWRP_LIBWRP_HPP_HPP
-#define LIBWRP_LIBWRP_HPP_HPP
+#ifndef LIBWRP_LIBWRP_HPP
+#define LIBWRP_LIBWRP_HPP
 
 
 // This file acts as a collective include header
@@ -10,4 +10,4 @@
 #include "version.hpp"
 
 
-#endif // LIBWRP_LIBWRP_HPP_HPP
+#endif // LIBWRP_LIBWRP_HPP

--- a/src/Basis.cpp
+++ b/src/Basis.cpp
@@ -8,7 +8,7 @@
  * @param molecule      Molecule object
  * @param basis_name    string
  */
-Wrapper::Basis::Basis(Molecule& molecule, const std::string& basis_name) :
+libwrp::Basis::Basis(Molecule& molecule, const std::string& basis_name) :
         molecule(molecule), name(basis_name) {
     // Constructing the basis also constructs the associated libint2::BasisSet object
     libint2::BasisSet libint_basis(this->name, this->molecule.atoms);
@@ -18,34 +18,34 @@ Wrapper::Basis::Basis(Molecule& molecule, const std::string& basis_name) :
 
 /** Calculate and return the number of basis functions in the basis
  */
-size_t Wrapper::Basis::nbf() {
+size_t libwrp::Basis::nbf() {
     return static_cast<size_t>(this->libint_basis.nbf());
 }
 
 
 /** Calculate and set the overlap integrals
  */
-void Wrapper::Basis::compute_overlap_integrals() {
+void libwrp::Basis::compute_overlap_integrals() {
     this->S = compute_1body_integrals(libint2::Operator::overlap, this->libint_basis, this->molecule.atoms);
 }
 
 
 /** Calculate and set the kinetic integrals
 */
-void Wrapper::Basis::compute_kinetic_integrals() {
+void libwrp::Basis::compute_kinetic_integrals() {
     this -> T = compute_1body_integrals(libint2::Operator::kinetic, this->libint_basis, this->molecule.atoms);
 }
 
 
 /** Calculate and set the nuclear integrals
 */
-void Wrapper::Basis::compute_nuclear_integrals() {
+void libwrp::Basis::compute_nuclear_integrals() {
     this-> V = compute_1body_integrals(libint2::Operator::nuclear, this->libint_basis, this->molecule.atoms);
 }
 
 
 /** Calculate and set the kinetic integrals
 */
-void Wrapper::Basis::compute_two_electron_integrals() {
+void libwrp::Basis::compute_two_electron_integrals() {
     this -> tei = compute_2body_integrals(this->libint_basis, this->molecule.atoms);
 };

--- a/src/Basis.cpp
+++ b/src/Basis.cpp
@@ -3,38 +3,49 @@
 #include "integrals.hpp"
 
 
-namespace Wrapper {
-
 /** Constructor from a molecule and a basis name.
  *
  * @param molecule      Molecule object
  * @param basis_name    string
  */
-Basis::Basis(Molecule& molecule, const std::string& basis_name) :
+Wrapper::Basis::Basis(Molecule& molecule, const std::string& basis_name) :
         molecule(molecule), name(basis_name) {
     // Constructing the basis also constructs the associated libint2::BasisSet object
     libint2::BasisSet libint_basis(this->name, this->molecule.atoms);
     this->libint_basis = libint_basis;
 }
 
-size_t Basis::nbf() {
+
+/** Calculate and return the number of basis functions in the basis
+ */
+size_t Wrapper::Basis::nbf() {
     return static_cast<size_t>(this->libint_basis.nbf());
 }
 
-Eigen::MatrixXd Basis::compute_overlap_integrals() {
-    return compute_1body_integrals(libint2::Operator::overlap, this->libint_basis, this->molecule.atoms);
+
+/** Calculate and set the overlap integrals
+ */
+void Wrapper::Basis::compute_overlap_integrals() {
+    this->S = compute_1body_integrals(libint2::Operator::overlap, this->libint_basis, this->molecule.atoms);
 }
 
-Eigen::MatrixXd Basis::compute_kinetic_integrals() {
-    return compute_1body_integrals(libint2::Operator::kinetic, this->libint_basis, this->molecule.atoms);
+
+/** Calculate and set the kinetic integrals
+*/
+void Wrapper::Basis::compute_kinetic_integrals() {
+    this -> T = compute_1body_integrals(libint2::Operator::kinetic, this->libint_basis, this->molecule.atoms);
 }
 
-Eigen::MatrixXd Basis::compute_nuclear_integrals() {
-    return compute_1body_integrals(libint2::Operator::nuclear, this->libint_basis, this->molecule.atoms);
+
+/** Calculate and set the nuclear integrals
+*/
+void Wrapper::Basis::compute_nuclear_integrals() {
+    this-> V = compute_1body_integrals(libint2::Operator::nuclear, this->libint_basis, this->molecule.atoms);
 }
 
-Eigen::Tensor<double, 4> Basis::compute_two_electron_integrals() {
-    return compute_2body_integrals(this->libint_basis, this->molecule.atoms);
+
+/** Calculate and set the kinetic integrals
+*/
+void Wrapper::Basis::compute_two_electron_integrals() {
+    this -> tei = compute_2body_integrals(this->libint_basis, this->molecule.atoms);
 };
-
-} // namespace Wrapper

--- a/src/Molecule.cpp
+++ b/src/Molecule.cpp
@@ -3,14 +3,12 @@
 #include "geometry.hpp"
 
 
-namespace Wrapper {
-
 /** Parses a file name to obtain atoms
  *
  * @param filename
  * @return std::vector<libint2::Atom>
  */
-std::vector<libint2::Atom> parse_filename(const std::string& filename) {
+std::vector<libint2::Atom> libwrp::parse_filename(const std::string& filename) {
     std::ifstream input_file_stream (filename);
     assert(input_file_stream.good());   // If this assertion fails, we know for sure that we specified a wrong relative path
     return libint2::read_dotxyz (input_file_stream);
@@ -23,7 +21,7 @@ std::vector<libint2::Atom> parse_filename(const std::string& filename) {
  * @param xyz_filename: the path to a .xyz-file that contains the geometry specifications of the molecule.
  *                      IMPORTANT!!! The coordinates of the atoms should be in Angstrom, but LibInt2, which actually processes the .xyz-file, automatically converts to a.u. (bohr).
  */
-Molecule::Molecule(const std::string& xyz_filename) :
+libwrp::Molecule::Molecule(const std::string& xyz_filename) :
         xyz_filename(xyz_filename)
 {
     this->atoms = parse_filename(this->xyz_filename);
@@ -42,7 +40,7 @@ Molecule::Molecule(const std::string& xyz_filename) :
      * @param xyz_filename: the path to a .xyz-file that contains the geometry specifications of the molecule.
      *                      IMPORTANT!!! The coordinates of the atoms should be in Angstrom, but LibInt2, which actually processes the .xyz-file, automatically converts to a.u. (bohr).
      */
-Molecule::Molecule(const std::string& xyz_filename, int molecular_charge) :
+libwrp::Molecule::Molecule(const std::string& xyz_filename, int molecular_charge) :
     xyz_filename(xyz_filename)
 {
     this->atoms = parse_filename(this->xyz_filename);
@@ -55,14 +53,14 @@ Molecule::Molecule(const std::string& xyz_filename, int molecular_charge) :
 
 /** @return the number of atoms in the molecule
  */
-size_t Molecule::natoms() {
+size_t libwrp::Molecule::natoms() {
     return this->atoms.size();  // atoms is a std::vector
 }
 
 
 /** @return the sum of the charges of the nuclei
  */
-unsigned Molecule::nucleic_charge() {
+unsigned libwrp::Molecule::nucleic_charge() {
     unsigned nucleic_charge = 0;
 
     for (const auto& atom : this->atoms) {
@@ -76,7 +74,7 @@ unsigned Molecule::nucleic_charge() {
 /** @return the internuclear repulsion energy due to the nuclear framework
  *
  */
-double Molecule::internuclear_repulsion() {
+double libwrp::Molecule::internuclear_repulsion() {
     double internuclear_repulsion_energy = 0.0;
 
     auto natoms = this->natoms();
@@ -87,11 +85,9 @@ double Molecule::internuclear_repulsion() {
             const auto atom2 = this->atoms[j];
 
             // The internuclear repulsion energy (Coulomb) for every nucleus pair is Z1 * Z2 / |R1 - R2|
-            internuclear_repulsion_energy += atom1.atomic_number * atom2.atomic_number / Wrapper::distance(atom1, atom2);
+            internuclear_repulsion_energy += atom1.atomic_number * atom2.atomic_number / libwrp::distance(atom1, atom2);
         }
     }
 
     return internuclear_repulsion_energy;
 }
-
-} // namespace Wrapper

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -1,13 +1,8 @@
 #include "geometry.hpp"
 
 
-namespace Wrapper {
-
 /** @return the distance between two libint2::Atoms, in Bohr
  */
-double distance(const libint2::Atom& atom1, const libint2::Atom& atom2) {
+double libwrp::distance(const libint2::Atom& atom1, const libint2::Atom& atom2) {
     return std::sqrt((atom1.x - atom2.x)*(atom1.x - atom2.x) + (atom1.y - atom2.y)*(atom1.y - atom2.y) + (atom1.z - atom2.z)*(atom1.z - atom2.z));
 }
-
-
-} // namespace Wrapper

--- a/src/integrals.cpp
+++ b/src/integrals.cpp
@@ -1,8 +1,6 @@
 #include "integrals.hpp"
 
 
-namespace Wrapper {
-
 /**
  * Given an operator type, an orbital basis and atoms, calculates the one-body integrals (associated to that operator type)
 
@@ -12,7 +10,7 @@ namespace Wrapper {
 
  * @return: an Eigen::MatrixXd storing the integrals
  */
-Eigen::MatrixXd compute_1body_integrals(const libint2::Operator& opertype, const libint2::BasisSet& obs, const std::vector<libint2::Atom>& atoms) {
+Eigen::MatrixXd libwrp::compute_1body_integrals(const libint2::Operator& opertype, const libint2::BasisSet& obs, const std::vector<libint2::Atom>& atoms) {
 
     const auto nsh = obs.size();    // nsh: number of shells in the obs
     const auto nbf = obs.nbf();     // nbf: number of basis functions in the obs
@@ -79,7 +77,7 @@ Eigen::MatrixXd compute_1body_integrals(const libint2::Operator& opertype, const
 
  * @return: an Eigen::Tensor<double, 4> storing the integrals
  */
-Eigen::Tensor<double, 4> compute_2body_integrals(const libint2::BasisSet& obs, const std::vector<libint2::Atom>& atoms) {
+Eigen::Tensor<double, 4> libwrp::compute_2body_integrals(const libint2::BasisSet& obs, const std::vector<libint2::Atom>& atoms) {
     // We have to static_cast to LONG, as clang++ else gives the following errors:
     //  error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'value_type' (aka 'long') in initializer list
     //  note: insert an explicit cast to silence this issue
@@ -152,12 +150,10 @@ Eigen::Tensor<double, 4> compute_2body_integrals(const libint2::BasisSet& obs, c
 /**
  * Prints the sizes (i.e. the number of basis functions in them) of all shells in a given basis set object.
  */
-void print_shell_sizes(const libint2::BasisSet& obs) {
+void libwrp::print_shell_sizes(const libint2::BasisSet& obs) {
     auto size = obs.size();
     for (auto i = 0; i < size; i++) {
         auto sh = obs[i]; // i traverses the shell
         std::cout << "Shell nr.: " << i << "\t Shell size: " << sh.size() << std::endl;
     }
 }
-
-} // namespace Wrapper

--- a/tests/Basis_test.cpp
+++ b/tests/Basis_test.cpp
@@ -80,8 +80,8 @@ BOOST_AUTO_TEST_CASE( constructor ) {
     const std::string xyzfilename = "../tests/ref_data/h2o.xyz";  // Specify the relative path to the input .xyz-file (w.r.t. the out-of-source build directory)
     const std::string basis_name = "STO-3G";
 
-    Wrapper::Molecule water (xyzfilename);
-    Wrapper::Basis basis (water, basis_name);
+    libwrp::Molecule water (xyzfilename);
+    libwrp::Basis basis (water, basis_name);
 
     BOOST_CHECK_EQUAL(basis.name, "STO-3G");
     BOOST_CHECK_EQUAL(basis.nbf(), 7);
@@ -97,8 +97,8 @@ BOOST_AUTO_TEST_CASE( horton_integrals_h2o_sto3g ) {
 
     const std::string xyzfilename = "../tests/ref_data/h2o.xyz";  // Specify the relative path to the input .xyz-file (w.r.t. the out-of-source build directory)
     const std::string basis_name = "STO-3G";
-    Wrapper::Molecule water (xyzfilename);
-    Wrapper::Basis basis (water, basis_name);
+    libwrp::Molecule water (xyzfilename);
+    libwrp::Basis basis (water, basis_name);
     auto nbf = basis.nbf();
 
     basis.compute_overlap_integrals();
@@ -135,9 +135,9 @@ BOOST_AUTO_TEST_CASE( szabo_h2_sto3g ) {
     const std::string basis_name = "STO-3G";
 
     // Create a Molecule and a Basis
-    Wrapper::Molecule h2 (xyzfilename);
+    libwrp::Molecule h2 (xyzfilename);
     BOOST_CHECK(std::abs(h2.atoms[1].z - 1.4) < 1.0e-6);    // Check if the conversion from Angstrom to a.u. is correct
-    Wrapper::Basis basis (h2, basis_name);
+    libwrp::Basis basis (h2, basis_name);
     BOOST_CHECK_EQUAL(basis.nbf(), 2);                      // Check if there are only two basis functions
 
     // Calculate S, T, V and H_core
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE( szabo_h2_sto3g ) {
     BOOST_CHECK(H_core.isApprox(H_core_ref, 1.0e-4));
 
 
-    // Calculate the two-electron integrals, and check the unique values listed in Szabo. These are given in chemist's notation in Szabo, so this confirms that this wrapper gives them in chemist's notation as well.
+    // Calculate the two-electron integrals, and check the unique values listed in Szabo. These are given in chemist's notation in Szabo, so this confirms that this libwrp gives them in chemist's notation as well.
     basis.compute_two_electron_integrals();
 
     BOOST_CHECK(std::abs(basis.tei(0,0,0,0) - 0.7746) < 1.0e-4);

--- a/tests/Basis_test.cpp
+++ b/tests/Basis_test.cpp
@@ -101,10 +101,10 @@ BOOST_AUTO_TEST_CASE( horton_integrals_h2o_sto3g ) {
     Wrapper::Basis basis (water, basis_name);
     auto nbf = basis.nbf();
 
-    Eigen::MatrixXd S = basis.compute_overlap_integrals();
-    Eigen::MatrixXd T = basis.compute_kinetic_integrals();
-    Eigen::MatrixXd V = basis.compute_nuclear_integrals();
-    Eigen::Tensor<double, 4> tei = basis.compute_two_electron_integrals();
+    basis.compute_overlap_integrals();
+    basis.compute_kinetic_integrals();
+    basis.compute_nuclear_integrals();
+    basis.compute_two_electron_integrals();
 
     Eigen::MatrixXd S_test (nbf, nbf);
     Eigen::MatrixXd T_test (nbf, nbf);
@@ -116,10 +116,10 @@ BOOST_AUTO_TEST_CASE( horton_integrals_h2o_sto3g ) {
     read_array_from_file("../tests/ref_data/nuclear.data", V_test);
     read_array_from_file("../tests/ref_data/two_electron.data", tei_test);
 
-    BOOST_CHECK(S.isApprox(S_test, 1.0e-8));
-    BOOST_CHECK(T.isApprox(T_test, 1.0e-8));
-    BOOST_CHECK(V.isApprox(V_test, 1.0e-8));
-    BOOST_CHECK(are_equal(tei, tei_test, 1.0e-6));
+    BOOST_CHECK(basis.S.isApprox(S_test, 1.0e-8));
+    BOOST_CHECK(basis.T.isApprox(T_test, 1.0e-8));
+    BOOST_CHECK(basis.V.isApprox(V_test, 1.0e-8));
+    BOOST_CHECK(are_equal(basis.tei, tei_test, 1.0e-6));
 
     // Finalize libint2
     libint2::finalize();
@@ -141,10 +141,10 @@ BOOST_AUTO_TEST_CASE( szabo_h2_sto3g ) {
     BOOST_CHECK_EQUAL(basis.nbf(), 2);                      // Check if there are only two basis functions
 
     // Calculate S, T, V and H_core
-    Eigen::MatrixXd S = basis.compute_overlap_integrals();
-    Eigen::MatrixXd T = basis.compute_kinetic_integrals();
-    Eigen::MatrixXd V = basis.compute_nuclear_integrals();
-    Eigen::MatrixXd H_core = T + V;
+    basis.compute_overlap_integrals();
+    basis.compute_kinetic_integrals();
+    basis.compute_nuclear_integrals();
+    Eigen::MatrixXd H_core = basis.T + basis.V;
 
     // Fill in the reference values from Szabo
     Eigen::MatrixXd S_ref (2, 2);
@@ -159,24 +159,23 @@ BOOST_AUTO_TEST_CASE( szabo_h2_sto3g ) {
     H_core_ref << -1.1204, -0.9584,
                   -0.9584, -1.1204;
 
-    BOOST_CHECK(S.isApprox(S_ref, 1.0e-4));
-    BOOST_CHECK(T.isApprox(T_ref, 1.0e-4));
+    BOOST_CHECK(basis.S.isApprox(S_ref, 1.0e-4));
+    BOOST_CHECK(basis.T.isApprox(T_ref, 1.0e-4));
     BOOST_CHECK(H_core.isApprox(H_core_ref, 1.0e-4));
 
 
     // Calculate the two-electron integrals, and check the unique values listed in Szabo. These are given in chemist's notation in Szabo, so this confirms that this wrapper gives them in chemist's notation as well.
-    Eigen::Tensor<double, 4> tei = basis.compute_two_electron_integrals();
+    basis.compute_two_electron_integrals();
 
-    BOOST_CHECK(std::abs(tei(0,0,0,0) - 0.7746) < 1.0e-4);
-    BOOST_CHECK(std::abs(tei(0,0,0,0) - tei(1,1,1,1)) < 1.0e-12);
+    BOOST_CHECK(std::abs(basis.tei(0,0,0,0) - 0.7746) < 1.0e-4);
+    BOOST_CHECK(std::abs(basis.tei(0,0,0,0) - basis.tei(1,1,1,1)) < 1.0e-12);
 
-    BOOST_CHECK(std::abs(tei(0,0,1,1) - 0.5697) < 1.0e-4);
+    BOOST_CHECK(std::abs(basis.tei(0,0,1,1) - 0.5697) < 1.0e-4);
 
-    BOOST_CHECK(std::abs(tei(1,0,0,0) - 0.4441) < 1.0e-4);
-    BOOST_CHECK(std::abs(tei(1,0,0,0) - tei(1,1,1,0)) < 1.0e-12);
+    BOOST_CHECK(std::abs(basis.tei(1,0,0,0) - 0.4441) < 1.0e-4);
+    BOOST_CHECK(std::abs(basis.tei(1,0,0,0) - basis.tei(1,1,1,0)) < 1.0e-12);
 
-    BOOST_CHECK(std::abs(tei(1,0,1,0) - 0.2970) < 1.0e-4);
-
+    BOOST_CHECK(std::abs(basis.tei(1,0,1,0) - 0.2970) < 1.0e-4);
 
     libint2::finalize();
 }

--- a/tests/Molecule_test.cpp
+++ b/tests/Molecule_test.cpp
@@ -12,10 +12,10 @@ BOOST_AUTO_TEST_CASE( constructor ) {
     //      !!! Apparently, when working with an out-of-source build, the 'working directory' for executables is the 'build' directory.
     //      !!! To make sure that no errors occur when building with CLion, specify the 'build' directory as 'working directory' in Edit Configurations.
     const std::string xyzfilename = "../tests/ref_data/h2o.xyz";  // Specify the relative path to the input .xyz-file (w.r.t. the out-of-source build directory)
-    Wrapper::Molecule water (xyzfilename);
-    Wrapper::Molecule water_anion (xyzfilename, -1);
-    Wrapper::Molecule water_neutral (xyzfilename, 0);
-    Wrapper::Molecule water_cation (xyzfilename, +1);
+    libwrp::Molecule water (xyzfilename);
+    libwrp::Molecule water_anion (xyzfilename, -1);
+    libwrp::Molecule water_neutral (xyzfilename, 0);
+    libwrp::Molecule water_cation (xyzfilename, +1);
 
     // Test the number of electrons created by the constructor
     BOOST_CHECK_EQUAL(water.nelec, 10);
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE ( methods_water ) {
 
     // Create the water molecule
     const std::string xyzfilename = "../tests/ref_data/h2o.xyz";  // Specify the relative path to the input .xyz-file (w.r.t. the out-of-source build directory)
-    Wrapper::Molecule water (xyzfilename);
+    libwrp::Molecule water (xyzfilename);
 
     // Test the basic methods
     BOOST_CHECK_EQUAL(water.natoms(), 3);
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE ( methods_h2 ) {
 
     // Create the water molecule
     const std::string xyzfilename = "../tests/ref_data/h2.xyz";  // Specify the relative path to the input .xyz-file (w.r.t. the out-of-source build directory)
-    Wrapper::Molecule h2 (xyzfilename);
+    libwrp::Molecule h2 (xyzfilename);
 
     // Test the basic methods
     BOOST_CHECK_EQUAL(h2.natoms(), 2);

--- a/tests/geometry_test.cpp
+++ b/tests/geometry_test.cpp
@@ -16,14 +16,14 @@ BOOST_AUTO_TEST_CASE ( distance ) {
     libint2::Atom D {0, 0, 0, 5};
 
     // Check their distances
-    BOOST_CHECK(std::abs(Wrapper::distance(A, B) - 5) < 1.0e-8);
-    BOOST_CHECK(std::abs(Wrapper::distance(A, C) - std::sqrt(18.0)) < 1.0e-8);
-    BOOST_CHECK(std::abs(Wrapper::distance(A, B) - Wrapper::distance(B, C)) < 1.0e-8);
-    BOOST_CHECK(std::abs(Wrapper::distance(B, C) - 5) < 1.0e-8);
-    BOOST_CHECK(std::abs(Wrapper::distance(B, D) - 1) < 1.0e-8);
+    BOOST_CHECK(std::abs(libwrp::distance(A, B) - 5) < 1.0e-8);
+    BOOST_CHECK(std::abs(libwrp::distance(A, C) - std::sqrt(18.0)) < 1.0e-8);
+    BOOST_CHECK(std::abs(libwrp::distance(A, B) - libwrp::distance(B, C)) < 1.0e-8);
+    BOOST_CHECK(std::abs(libwrp::distance(B, C) - 5) < 1.0e-8);
+    BOOST_CHECK(std::abs(libwrp::distance(B, D) - 1) < 1.0e-8);
 
     // Check that the distances are symmetric
-    BOOST_CHECK(std::abs(Wrapper::distance(A, B) - Wrapper::distance(B, A)) < 1.0e-8);
-    BOOST_CHECK(std::abs(Wrapper::distance(A, C) - Wrapper::distance(C, A)) < 1.0e-8);
-    BOOST_CHECK(std::abs(Wrapper::distance(B, C) - Wrapper::distance(C, B)) < 1.0e-8);
+    BOOST_CHECK(std::abs(libwrp::distance(A, B) - libwrp::distance(B, A)) < 1.0e-8);
+    BOOST_CHECK(std::abs(libwrp::distance(A, C) - libwrp::distance(C, A)) < 1.0e-8);
+    BOOST_CHECK(std::abs(libwrp::distance(B, C) - libwrp::distance(C, B)) < 1.0e-8);
 }


### PR DESCRIPTION
v2.0.0 features:
- the namespace `libwrp` instead of the deprecated `Wrapper`
- calculated integrals can now be accessed inside the `Basis` object